### PR TITLE
close boards for completed sprints

### DIFF
--- a/.github/workflows/sprint-board-maintenance.yml
+++ b/.github/workflows/sprint-board-maintenance.yml
@@ -48,3 +48,9 @@ jobs:
           pipenv run moc-sprint-tools -v cards-missing-from-backlog
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+
+      - name: "Close out old sprints"
+        run: |
+          pipenv run moc-sprint-tools -v close-sprint-boards
+        env:
+          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,3 @@ verify_ssl = true
 pygithub = "*"
 click = "*"
 jinja2 = "*"
-
-[requires]
-python_version = "3.8"

--- a/moc_sprint_tools/cli.py
+++ b/moc_sprint_tools/cli.py
@@ -8,6 +8,7 @@ from moc_sprint_tools import label_cards_in_sprint
 from moc_sprint_tools import label_needs_description
 from moc_sprint_tools import sort_cards_by_priority
 from moc_sprint_tools import cards_missing_from_backlog
+from moc_sprint_tools import close_sprint_boards
 from moc_sprint_tools import utils
 
 from moc_sprint_tools.sprintman import Sprintman
@@ -36,6 +37,7 @@ main.add_command(label_cards_in_sprint.main)
 main.add_command(label_needs_description.main)
 main.add_command(sort_cards_by_priority.main)
 main.add_command(cards_missing_from_backlog.main)
+main.add_command(close_sprint_boards.main)
 main.add_command(utils.shell)
 main.add_command(utils.repos)
 main.add_command(utils.boards)

--- a/moc_sprint_tools/close_sprint_boards.py
+++ b/moc_sprint_tools/close_sprint_boards.py
@@ -1,0 +1,28 @@
+import click
+import datetime
+import github
+import logging
+
+LOG = logging.getLogger(__name__)
+DEFAULT_BOARD_AGE = 28
+
+
+@click.command(name='close-sprint-boards')
+@click.option('--age', '-a', type=int, default=DEFAULT_BOARD_AGE)
+@click.pass_context
+def main(ctx, age):
+    api = ctx.obj
+
+    try:
+        for board in api.open_sprints:
+            now = datetime.datetime.utcnow()
+            delta = now - board.created_at
+            if delta.days >= age:
+                LOG.info('Closing board %s', board.name)
+
+                # LKS: we need to specify the `name` attribute here
+                # until https://github.com/PyGithub/PyGithub/pull/1817
+                # has merged.
+                board.edit(name=board.name, state='closed')
+    except github.GithubException as err:
+        raise click.ClickException(err)


### PR DESCRIPTION
This will close sprint boards 28 days after they were created.

This assumes that we're not creating sprint boards far in advance of
the sprint (which if we resolve #1 should be a reasonable assumption).
