### PR TITLE
Fix date handling logic in create_sprint_boards

### DIFF
--- a/.github/workflows/sprint-board-maintenance.yml
+++ b/.github/workflows/sprint-board-maintenance.yml
@@ -54,3 +54,9 @@ jobs:
           pipenv run moc-sprint-tools -v close-sprint-boards
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+
+      - name: "Create new sprints"
+        run: |
+          pipenv run moc-sprint-tools -v create-sprint-boards
+        env:
+          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/sprint-board-maintenance.yml
+++ b/.github/workflows/sprint-board-maintenance.yml
@@ -54,9 +54,3 @@ jobs:
           pipenv run moc-sprint-tools -v close-sprint-boards
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
-
-      - name: "Create new sprints"
-        run: |
-          pipenv run moc-sprint-tools -v create-sprint-boards
-        env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/config/sprint_dates.csv
+++ b/config/sprint_dates.csv
@@ -3,3 +3,4 @@ Sprint week 1 and 2 2021,2021-01-04
 Sprint week 3 and 4 2021,2021-01-19
 Sprint week 5 and 6 2021,2021-02-01
 Sprint week 7 and 8 2021,2021-02-17
+Sprint week 9 and 10 2021,2021-03-03

--- a/moc_sprint_tools/create_sprint_boards.py
+++ b/moc_sprint_tools/create_sprint_boards.py
@@ -85,6 +85,7 @@ def main(ctx, file, copy_cards):
 
                 if line > 0:
                     previous_sprint = sprints[line - 1]
+            else:
                 break
 
         if not current_sprint:

--- a/moc_sprint_tools/create_sprint_boards.py
+++ b/moc_sprint_tools/create_sprint_boards.py
@@ -43,8 +43,7 @@ def copy_card(source_card, destination_column):
             LOG.warning('Couldn\'t copy card with unkown type')
             return
 
-        LOG.info('adding card "%s" to %s', (content.title,
-                                            destination_column.name))
+        LOG.info('adding card "%s" to %s', content.title, destination_column.name)
         destination_column.create_card(
             content_id=content.id,
             content_type=content_type,

--- a/moc_sprint_tools/create_sprint_boards.py
+++ b/moc_sprint_tools/create_sprint_boards.py
@@ -10,7 +10,7 @@ LOG = logging.getLogger(__name__)
 
 CARD_COPYING_MAP = {
     'notes': 'notes',
-    'backlog': 'backlog',
+    'sprint backlog': 'sprint backlog',
     'in progress': 'in progress'
 }
 

--- a/moc_sprint_tools/defaults.py
+++ b/moc_sprint_tools/defaults.py
@@ -1,2 +1,2 @@
 default_organization = 'CCI-MOC'
-default_sprint_columns = ['Notes', 'Backlog', 'In Progress', 'Done']
+default_sprint_columns = ['Notes', 'Sprint Backlog', 'In Progress', 'Done']


### PR DESCRIPTION
The loop would break prematurely because it was breaking when
today > sprint start, which would be the case for all sprints that
started in the past. Instead, the loop should break when that case
is not true anymore, and use the last matching line.

This also reenables the command in the board maintenance action.

Closes #10 