### PR TITLE
move get_column into sprintman.Sprintman

### DIFF
--- a/moc_sprint_tools/cmd/create_sprint_boards.py
+++ b/moc_sprint_tools/cmd/create_sprint_boards.py
@@ -26,12 +26,6 @@ def load_sprint_data(input_file):
     return sprints
 
 
-def get_column(board, name):
-    for c in board.get_columns():
-        if c.name.lower() == name.lower():
-            return c
-
-
 def copy_card(source_card, destination_column):
     content = source_card.get_content()
     if content:
@@ -52,13 +46,14 @@ def copy_card(source_card, destination_column):
         destination_column.create_card(note=source_card.note)
 
 
-def copy_board(source_board, destination_board):
+def copy_board(api, source_board, destination_board):
     for source in source_board.get_columns():
         destination = CARD_COPYING_MAP.get(source.name.lower(), None)
         if not destination:
             continue
 
-        destination = get_column(destination_board, destination)
+        # XXX: what if this fails?
+        destination = api.get_column(destination_board, destination)
         cards = list(source.get_cards())
         cards.reverse()  # Creating a card adds it to the top
 
@@ -101,7 +96,7 @@ def main(ctx, file, copy_cards):
 
             if previous_sprint and copy_cards:
                 previous_board = api.get_sprint(previous_sprint[0])
-                copy_board(previous_board, board)
+                copy_board(api, previous_board, board)
 
     except github.GithubException as err:
         raise click.ClickException(err)

--- a/moc_sprint_tools/sprintman.py
+++ b/moc_sprint_tools/sprintman.py
@@ -56,6 +56,11 @@ class Sprintman(github.Github):
 
         return board
 
+    def get_column(self, board, name):
+        for c in board.get_columns():
+            if c.name.lower() == name.lower():
+                return c
+
     def create_sprint(self, name):
         board = self.organization.create_project(name)
         board.edit(private=False)

--- a/moc_sprint_tools/sprintman.py
+++ b/moc_sprint_tools/sprintman.py
@@ -1,7 +1,7 @@
 import github
 import logging
 
-from functools import wraps
+from functools import cached_property
 
 from moc_sprint_tools import defaults
 
@@ -18,28 +18,13 @@ class BoardNotFoundError(ApplicationError):
     pass
 
 
-def cached(func):
-    @wraps(func)
-    def wrapped(self, *args, **kwargs):
-        attr = f'_{func.__name__}'
-        if hasattr(self, attr):
-            return getattr(self, attr)
-
-        res = func(self, *args, **kwargs)
-        setattr(self, attr, res)
-        return res
-
-    return wrapped
-
-
 class Sprintman(github.Github):
     def __init__(self, token, org_name=None, backlog_name=None):
         super().__init__(token)
         self._org_name = org_name if org_name else DEFAULT_ORG
         self._backlog_name = backlog_name if backlog_name else DEFAULT_BACKLOG
 
-    @property
-    @cached
+    @cached_property
     def organization(self):
         return self.get_organization(self._org_name)
 
@@ -49,7 +34,6 @@ class Sprintman(github.Github):
             if board.name.lower().strip().startswith('sprint'):
                 yield board
 
-    @cached
     def get_sprint(self, name):
         for board in self.open_sprints:
             if board.name.lower() == name.lower():


### PR DESCRIPTION
the get_column method seems like a useful library function, so move it from the
create-sprint-boards command into the sprintman api module.

applies on top of #13
