### PR TITLE
Ensure we process sprints in sorted order

### DIFF
--- a/moc_sprint_tools/cmd/create_sprint_boards.py
+++ b/moc_sprint_tools/cmd/create_sprint_boards.py
@@ -79,7 +79,7 @@ def main(ctx, file, copy_cards):
         previous_sprint = None
         today = datetime.datetime.utcnow()
 
-        for line, sprint in enumerate(sprints):
+        for line, sprint in enumerate(sorted(sprints, key=lambda x: x[1])):
             if today > sprint[1]:
                 current_sprint = sprint
 


### PR DESCRIPTION
The logic that calculates the previous sprint would fail if
sprints were unsorted in the config file.

Ensure that we sort sprints by date.