### PR TITLE
Feature/template titles

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = H238, E501
+ignore = H238, E501, E266

--- a/config/sprint_dates.csv
+++ b/config/sprint_dates.csv
@@ -1,6 +1,0 @@
-﻿Sprint Name,Sprint Start Date
-Sprint week 1 and 2 2021,2021-01-04
-Sprint week 3 and 4 2021,2021-01-19
-Sprint week 5 and 6 2021,2021-02-01
-Sprint week 7 and 8 2021,2021-02-17
-Sprint week 9 and 10 2021,2021-03-03

--- a/moc_sprint_tools/cmd/create_sprint_boards.py
+++ b/moc_sprint_tools/cmd/create_sprint_boards.py
@@ -1,7 +1,8 @@
 import click
-import csv
 import datetime
 import github
+import jinja2
+import json
 import logging
 
 from moc_sprint_tools.sprintman import BoardNotFoundError
@@ -9,56 +10,126 @@ from moc_sprint_tools.sprintman import BoardNotFoundError
 LOG = logging.getLogger(__name__)
 
 
-def load_sprint_data(input_file):
+def Date(val):
+    if val in ['now', 'today']:
+        date = datetime.date.today()
+    else:
+        date = datetime.date.fromisoformat(val)
+
+    if date is None:
+        raise ValueError(val)
+
+    return date
+
+
+def dump_date_as_iso8601(val):
+    if isinstance(val, datetime.date):
+        return val.isoformat()
+    else:
+        return val
+
+
+def check_overlaps(api, date):
+    conflicts = []
     sprints = []
-    with open(input_file) as f:
-        reader = csv.reader(f)
-        next(f)
-        for row in reader:
-            sprints.append(
-                [row[0], datetime.datetime.strptime(row[1], '%Y-%m-%d')])
-    return sprints
+
+    for sprint in api.open_sprints:
+        try:
+            md = json.loads(sprint.body)
+        except (TypeError, json.decoder.JSONDecodeError):
+            continue
+
+        for attr in ['week1', 'week2']:
+            md[attr] = datetime.date.fromisoformat(md[attr])
+
+        sprints.append((md['week1'], md['week2'], sprint))
+
+        if md['week1'] < date < md['week2'] + datetime.timedelta(days=7):
+            conflicts.append(sprint)
+
+    try:
+        prev_week1, prev_week2, prev_board = sorted(sprints)[-1]
+        if prev_week1 >= date:
+            prev_board = None
+    except IndexError:
+        prev_board = None
+
+    return prev_board, conflicts
 
 
 @click.command(name='create-sprint-boards')
-@click.option('--file', '-f', type=str, default='./config/sprint_dates.csv')
 @click.option('--copy-cards/--no-copy-cards', default=True)
+@click.option('--date', '-d', type=Date, default='now')
+@click.option('--templates', '-t')
+@click.option('--force', '-f', is_flag=True)
+@click.option('--check-only', '-n', is_flag=True)
 @click.pass_context
-def main(ctx, file, copy_cards):
+def main(ctx, date, templates, copy_cards, force, check_only):
     api = ctx.obj
 
+    loaders = []
+    if templates:
+        loaders.append(jinja2.FileSystemLoader(templates))
+    loaders.append(jinja2.PackageLoader('moc_sprint_tools'))
+
+    env = jinja2.Environment(
+        loader=jinja2.ChoiceLoader(loaders),
+    )
+    env.globals['api'] = api
+
     try:
-        sprints = load_sprint_data(file)
-        current_sprint = None
-        previous_sprint = None
-        today = datetime.datetime.utcnow()
+        week1 = date
+        week2 = date + datetime.timedelta(days=7)
 
-        for line, sprint in enumerate(sorted(sprints, key=lambda x: x[1])):
-            if today > sprint[1]:
-                current_sprint = sprint
+        sprint_title = env.get_template('sprint_title.j2').render(
+            week1=week1, week2=week2
+        )
 
-                if line > 0:
-                    previous_sprint = sprints[line - 1]
-            else:
-                break
+        sprint_description = json.dumps(dict(
+            week1=week1,
+            week2=week2
+        ), default=dump_date_as_iso8601)
 
-        if not current_sprint:
-            LOG.warning('No sprint is current')
-            return
+        # check if board exists
 
         try:
-            api.get_sprint(current_sprint[0])
-            LOG.warning('Sprint board "%s" already exists.' % current_sprint[0])
+            api.get_sprint(sprint_title)
+            LOG.warning('sprint board "%s" already exists.' % sprint_title)
             return
         except BoardNotFoundError:
-            board = api.create_sprint(current_sprint[0])
+            LOG.info('preparing to create sprint board "%s"' % sprint_title)
 
-            if previous_sprint and copy_cards:
-                try:
-                    previous_board = api.get_sprint(previous_sprint[0])
-                    api.copy_board(previous_board, board)
-                except BoardNotFoundError:
-                    LOG.error('previous sprint board %s does not exist', previous_sprint[0])
+        # check for overlap with existing sprint
+
+        previous, conflicts = check_overlaps(api, week1)
+        LOG.debug('found previous board: %s', previous)
+        LOG.debug('found conflicts: %s', conflicts)
+        if conflicts and not force:
+            titles = ', '.join(sprint.name for sprint in conflicts)
+            raise click.ClickException(
+                f'new sprint {sprint_title} overlaps with {titles}')
+
+        if previous:
+            LOG.info('found previous sprint %s', previous.name)
+
+        if check_only:
+            return
+
+        ##
+        ## create resources after this point
+        ##
+
+        # create project board
+
+        LOG.info('creating board %s', sprint_title)
+        board = api.create_sprint(sprint_title, body=sprint_description)
+
+        # copy cards if requested
+        if copy_cards and previous:
+            LOG.info('copying cards from %s', previous.name)
+            api.copy_board(previous, board)
+        elif copy_cards:
+            LOG.warning('not copying cards (no previous board)')
 
     except github.GithubException as err:
         raise click.ClickException(err)

--- a/moc_sprint_tools/cmd/create_sprint_boards.py
+++ b/moc_sprint_tools/cmd/create_sprint_boards.py
@@ -12,6 +12,12 @@ LOG = logging.getLogger(__name__)
 
 
 def Date(val):
+    '''transform date on the command line into a datetime.date object
+
+    the values 'now' and 'today' both evaluate to the current day
+    (datetime.date.today()).
+    '''
+
     if val in ['now', 'today']:
         date = datetime.date.today()
     else:
@@ -24,12 +30,20 @@ def Date(val):
 
 
 def find_notes_issue(repo, title):
+    '''find an issue by title in the specified repository'''
+
     for issue in repo.get_issues(state='open'):
         if issue.title == title:
             return issue
 
 
 def dump_date_as_iso8601(val):
+    '''serialize datetime.date objects to JSON
+
+    used when calling json.dump/json.dumps on objects
+    that contain datetime.date values
+    '''
+
     if isinstance(val, datetime.date):
         return val.isoformat()
     else:
@@ -37,6 +51,14 @@ def dump_date_as_iso8601(val):
 
 
 def check_overlaps(api, date):
+    '''look for existing sprints that conflict with the current date
+
+    since this function has to iterate through all existing sprint boards,
+    it also calculates the immediately prior sprint.
+
+    returns a (previous_board, list_of_conflicts) tuple to the caller.
+    '''
+
     conflicts = []
     sprints = []
 
@@ -73,6 +95,15 @@ def check_overlaps(api, date):
 @click.option('--notes-repo', '-N', default=defaults.default_sprint_notes_repo)
 @click.pass_context
 def main(ctx, date, templates, force, check_only, notes_repo, copy_cards):
+    '''create sprint board for the current date
+
+    create a new project board for a sprint beginning on the current date (or
+    on the argument to --date, if provided). create-sprint-board will not
+    create a sprint board if one with the same name already exists. It will not
+    create a sprint board if the dates overlap with an existing open sprint
+    unless you provide the --force option.
+    '''
+
     api = ctx.obj
 
     loaders = []

--- a/moc_sprint_tools/defaults.py
+++ b/moc_sprint_tools/defaults.py
@@ -1,3 +1,4 @@
 default_organization = 'CCI-MOC'
 default_sprint_columns = ['Notes', 'Sprint Backlog', 'In Progress', 'Done']
 default_skip_copy = ['notes', 'done']
+default_sprint_notes_repo = 'sprint-notes'

--- a/moc_sprint_tools/templates/backlog_note.j2
+++ b/moc_sprint_tools/templates/backlog_note.j2
@@ -1,0 +1,3 @@
+[0] Backlog
+
+{{ api.backlog.html_url }}

--- a/moc_sprint_tools/templates/sprint_description.j2
+++ b/moc_sprint_tools/templates/sprint_description.j2
@@ -1,0 +1,1 @@
+Sprint for week {{ week1.isocalendar().week }} and {{ week2.isocalendar().week }}, {{ week1.year }}

--- a/moc_sprint_tools/templates/sprint_notes_description.j2
+++ b/moc_sprint_tools/templates/sprint_notes_description.j2
@@ -1,0 +1,1 @@
+Enter notes from daily standups as comments on this issue.

--- a/moc_sprint_tools/templates/sprint_notes_title.j2
+++ b/moc_sprint_tools/templates/sprint_notes_title.j2
@@ -1,0 +1,1 @@
+Sprint notes for week {{ week1.isocalendar().week }} and {{ week2.isocalendar().week }} {{ week1.year }}

--- a/moc_sprint_tools/templates/sprint_title.j2
+++ b/moc_sprint_tools/templates/sprint_title.j2
@@ -1,0 +1,1 @@
+Sprint week {{ week1.isocalendar().week }} and {{ week2.isocalendar().week }} {{ week1.year }}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import click.testing
-import datetime
 import pytest
 
 from unittest import mock
@@ -31,50 +30,3 @@ def test_main_override_org(api_class, runner):
     res = runner.invoke(moc_sprint_tools.cli.main, '-o fake_org shell')
     assert res.exit_code == 0
     assert api_class.call_args[1]['org_name'] == 'fake_org'
-
-
-def test_create_sprint_boards_no_copy(api, org, runner, projects):
-    today = datetime.datetime.now()
-    today.replace(hour=0, minute=0, second=0)
-    api.get_sprint.side_effect = moc_sprint_tools.sprintman.BoardNotFoundError
-
-    with mock.patch('moc_sprint_tools.cmd.create_sprint_boards.load_sprint_data') as load_sprint_data:
-        load_sprint_data.return_value = [
-            ('Test Sprint', today)
-        ]
-
-        res = runner.invoke(moc_sprint_tools.cli.main, 'create-sprint-boards', '--no-copy-cards')
-        assert res.exit_code == 0
-        assert api.create_sprint.call_args_list[0][0] == ('Test Sprint',)
-
-
-def test_create_sprint_boards_duplicate_no_copy(caplog, api, org, runner, projects):
-    today = datetime.datetime.now()
-    today.replace(hour=0, minute=0, second=0)
-    api.get_sprint.return_value = projects[0]
-
-    with mock.patch('moc_sprint_tools.cmd.create_sprint_boards.load_sprint_data') as load_sprint_data:
-        load_sprint_data.return_value = [
-            (projects[0].name, today)
-        ]
-
-        res = runner.invoke(moc_sprint_tools.cli.main, 'create-sprint-boards', '--no-copy-cards')
-        assert res.exit_code == 0
-        assert not api.create_sprint.call_args_list
-
-
-@pytest.mark.skip(reason='create-sprint-boards needs work')
-def test_create_sprint_boards_copy(api, org, runner, projects):
-    today = datetime.datetime.now()
-    today.replace(hour=0, minute=0, second=0)
-    api.get_sprint.side_effect = moc_sprint_tools.sprintman.BoardNotFoundError
-
-    with mock.patch('moc_sprint_tools.cmd.create_sprint_boards.load_sprint_data') as load_sprint_data:
-        load_sprint_data.return_value = [
-            ('Test Sprint 1', today - datetime.timedelta(weeks=1)),
-            ('Test Sprint 2', today)
-        ]
-
-        res = runner.invoke(moc_sprint_tools.cli.main, 'create-sprint-boards')
-        assert res.exit_code == 0
-        assert api.create_sprint.call_args_list[0][0] == ('Test Sprint 2',)

--- a/tests/test_cli_create_sprint_boards.py
+++ b/tests/test_cli_create_sprint_boards.py
@@ -1,0 +1,120 @@
+import click.testing
+import pytest
+
+from unittest import mock
+
+import moc_sprint_tools.cli
+import moc_sprint_tools.sprintman
+
+
+@pytest.fixture
+def api(api_class, org):
+    mock_api_object = mock.Mock()
+    mock_api_object.organization = org
+    api_class.return_value = mock_api_object
+
+    yield mock_api_object
+
+
+@pytest.fixture
+def runner():
+    return click.testing.CliRunner()
+
+
+def test_create_sprint_boards(api, runner):
+    '''create new sprint board.'''
+
+    expected_title = 'Sprint week 5 and 6 2021'
+    expected_body = '{"week1": "2021-02-01", "week2": "2021-02-08"}'
+
+    mock_repo = mock.Mock()
+    mock_repo.get_issues.return_value = []
+    api.organization.get_repo.return_value = mock_repo
+
+    api.open_sprints = []
+    api.get_sprint.side_effect = moc_sprint_tools.sprintman.BoardNotFoundError
+
+    res = runner.invoke(moc_sprint_tools.cli.main,
+                        'create-sprint-boards -d 2021-02-01')
+    assert res.exception is None
+    assert res.exit_code == 0
+    assert api.create_sprint.call_args_list[0][0][0] == expected_title
+    assert api.create_sprint.call_args_list[0][1]['body'] == expected_body
+
+
+def test_create_sprint_boards_with_duplicate(api, runner, caplog):
+    '''create new sprint board when one already exists with the same name'''
+
+    expected_title = 'Sprint week 5 and 6 2021'
+
+    api.open_sprints = []
+    api.get_sprint.return_value = mock.Mock()
+
+    res = runner.invoke(moc_sprint_tools.cli.main,
+                        'create-sprint-boards -d 2021-02-01')
+    assert res.exception is None
+    assert res.exit_code == 0
+    assert not api.create_sprint.called
+    assert f'board "{expected_title}" already exists' in caplog.text
+
+
+def test_create_sprint_boards_with_conflict(api, runner, caplog):
+    '''create new sprint board that overlaps with existing sprint board'''
+
+    mock_repo = mock.Mock()
+    mock_repo.get_issues.return_value = []
+    api.organization.get_repo.return_value = mock_repo
+
+    api.open_sprints = [
+        mock.Mock(),
+    ]
+    api.open_sprints[0].body = '{"week1": "2021-01-22", "week2": "2021-02-08"}'
+    api.open_sprints[0].name = 'Test Sprint'
+
+    api.get_sprint.side_effect = moc_sprint_tools.sprintman.BoardNotFoundError
+
+    res = runner.invoke(moc_sprint_tools.cli.main,
+                        'create-sprint-boards -d 2021-02-01')
+    assert res.exit_code == 1
+
+
+def test_create_sprint_boards_with_create_issue(api, runner):
+    '''create new sprint board, verify new issue is created'''
+
+    expected_issue_title = 'Sprint notes for week 5 and 6 2021'
+
+    mock_repo = mock.Mock()
+    mock_repo.get_issues.return_value = []
+    api.organization.get_repo.return_value = mock_repo
+
+    api.open_sprints = []
+    api.get_sprint.side_effect = moc_sprint_tools.sprintman.BoardNotFoundError
+
+    res = runner.invoke(moc_sprint_tools.cli.main,
+                        'create-sprint-boards -d 2021-02-01')
+    assert res.exception is None
+    assert res.exit_code == 0
+    assert mock_repo.create_issue.call_args_list[0][1]['title'] == expected_issue_title
+
+
+def test_create_sprint_boards_with_existing_issue(api, runner):
+    '''create new sprint board, use existing notes issue'''
+
+    mock_repo = mock.Mock(full_name='test/repo')
+    mock_repo.get_issues.return_value = [
+        mock.Mock(
+            title='Sprint notes for week 5 and 6 2021',
+            number=1,
+            repository=mock_repo
+        )
+    ]
+
+    api.open_sprints = []
+    api.organization.get_repo.return_value = mock_repo
+    api.get_sprint.side_effect = moc_sprint_tools.sprintman.BoardNotFoundError
+
+    res = runner.invoke(moc_sprint_tools.cli.main,
+                        'create-sprint-boards -d 2021-02-01')
+    assert res.exception is None
+    assert res.exit_code == 0
+    assert not mock_repo.create_issue.called


### PR DESCRIPTION
- Produce sprint board titles from templates and the current date, rather than from a config file.
- Store metadata in the sprint board description so we can detect overlap between sprints and sort sprints by date.
- Create sprint notes issues when creating new sprint board
- Include tests for create-sprint-board