### PR TITLE
Improve create-sprint-boards code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = H238, E501, E266
+ignore = H238, E501, E266, W503

--- a/.github/workflows/create-sprint-board.yml
+++ b/.github/workflows/create-sprint-board.yml
@@ -27,8 +27,7 @@ jobs:
 
       - name: "Create sprint boards"
         run: |
-          # ignore errors from this command because we expect it to fail
-          # every other week
-          pipenv run moc-sprint-tools -v create-sprint-boards --no-copy-cards || :
+          pipenv run moc-sprint-tools -v create-sprint-boards \
+            --no-copy-cards --conflict-is-warning
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: run unit tests
 on:
   push:
+  pull_request:
 
 jobs:
   run-unit-tests:
@@ -13,5 +14,7 @@ jobs:
 
       - run: pip install pipenv
       - run: pipenv install -d
+      - run: >
+          pipenv run flake8 moc_sprint_tools
       - run: >
           pipenv run pytest -v --cov=moc_sprint_tools

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 pytest-cov = "*"
+flake8 = "*"
 
 [packages]
 pygithub = "*"

--- a/moc_sprint_tools/sprintman.py
+++ b/moc_sprint_tools/sprintman.py
@@ -17,7 +17,17 @@ class ApplicationError(Exception):
 
 
 class BoardNotFoundError(ApplicationError):
+    '''Reference to a board that does not exist.'''
     pass
+
+
+class BoardConflictError(ApplicationError):
+    '''Attempt to create a board that overlaps an existing board'''
+    pass
+
+
+class BoardExistsError(ApplicationError):
+    '''Attempt to create a board with the same name as an existing board.'''
 
 
 # XXX: there should probably be some error handling inside


### PR DESCRIPTION
Previously, we ignored any errors from create-sprint-boards because we
expected it to throw an error every other weeks (because it runs
weekly, but every other week there would be a conflict with the active
sprint). This masked actual errors, so this commit makes the following
changes:

- Add the --conflict-is-warning flag, which causes
  create-sprint-boards to log a warning and exit successfully if there
  is a conflict
- Add some explicit logging around the code that has been causing
  failures

Part of #26
