### PR TITLE
feature/remove done issues

### DIFF
--- a/.github/workflows/sprint-board-maintenance-daily.yml
+++ b/.github/workflows/sprint-board-maintenance-daily.yml
@@ -1,0 +1,38 @@
+---
+name: "Sprint board daily maintenance"
+on:
+  schedule:
+    - cron: '15 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  label_open_boards:
+    name: "Sprint board daily maintenance"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+
+      - name: "Set up python"
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+          pipenv install -e .
+
+      - name: "Close out old sprints"
+        run: |
+          pipenv run moc-sprint-tools -v close-sprint-boards
+        env:
+          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+
+      - name: "Remove done cards from backlog"
+        run: |
+          pipenv run moc-sprint-tools -v remove-done-cards
+        env:
+          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/sprint-board-maintenance-hourly.yml
+++ b/.github/workflows/sprint-board-maintenance-hourly.yml
@@ -1,5 +1,5 @@
 ---
-name: "Sprint board maintenance"
+name: "Sprint board hourly(-ish) maintenance"
 on:
   schedule:
     - cron: '0 */2 * * *'
@@ -7,7 +7,7 @@ on:
 
 jobs:
   label_open_boards:
-    name: "Sprint board maintenance"
+    name: "Sprint board hourly maintenance"
     runs-on: ubuntu-latest
 
     steps:
@@ -31,12 +31,6 @@ jobs:
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
 
-      - name: "Sort priority tagged cards"
-        run: |
-          pipenv run moc-sprint-tools -v sort-cards-by-priority
-        env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
-
       - name: "Add needs_description label"
         run: |
           pipenv run moc-sprint-tools -v label-needs-description
@@ -46,11 +40,5 @@ jobs:
       - name: "Add missing cards to backlog"
         run: |
           pipenv run moc-sprint-tools -v cards-missing-from-backlog
-        env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
-
-      - name: "Close out old sprints"
-        run: |
-          pipenv run moc-sprint-tools -v close-sprint-boards
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/sprint-board-maintenance.yml
+++ b/.github/workflows/sprint-board-maintenance.yml
@@ -2,7 +2,7 @@
 name: "Sprint board maintenance"
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
 
 jobs:

--- a/moc_sprint_tools/cli.py
+++ b/moc_sprint_tools/cli.py
@@ -13,6 +13,7 @@ from moc_sprint_tools.cmd import create_sprint_boards
 from moc_sprint_tools.cmd import label_cards_in_sprint
 from moc_sprint_tools.cmd import label_needs_description
 from moc_sprint_tools.cmd import sort_cards_by_priority
+from moc_sprint_tools.cmd import remove_done_cards
 
 from moc_sprint_tools.sprintman import Sprintman
 
@@ -43,6 +44,7 @@ main.add_command(create_sprint_boards.main)
 main.add_command(label_cards_in_sprint.main)
 main.add_command(label_needs_description.main)
 main.add_command(sort_cards_by_priority.main)
+main.add_command(remove_done_cards.main)
 main.add_command(utils.shell)
 main.add_command(utils.repos)
 main.add_command(utils.boards)

--- a/moc_sprint_tools/cmd/remove_done_cards.py
+++ b/moc_sprint_tools/cmd/remove_done_cards.py
@@ -1,0 +1,41 @@
+import click
+import datetime
+import github
+import logging
+
+from moc_sprint_tools import defaults
+
+LOG = logging.getLogger(__name__)
+
+
+@click.command(name='remove-done-issues')
+@click.option('--days', '-d', type=int, default=defaults.default_days_done)
+@click.pass_context
+def main(ctx, days):
+    api = ctx.obj
+    delta = datetime.timedelta(days=days)
+    now = datetime.datetime.utcnow()
+
+    try:
+        done = next(
+            x for x in api.backlog.get_columns() if x.name.lower() == 'done'
+        )
+
+        for card in done.get_cards():
+            if card.note:
+                LOG.debug("skipping note")
+                continue
+
+            content = card.get_content()
+            if not content.closed_at:
+                LOG.debug('skipping "%s" (not closed)', content.title)
+                continue
+
+            if now - content.closed_at < delta:
+                LOG.debug('skipping "%s" (too recent)', content.title)
+                continue
+
+            LOG.info('removing "%s" from project', content.title)
+            card.delete()
+    except github.GithubException as err:
+        raise click.ClickException(err)

--- a/moc_sprint_tools/defaults.py
+++ b/moc_sprint_tools/defaults.py
@@ -2,3 +2,4 @@ default_organization = 'CCI-MOC'
 default_sprint_columns = ['Notes', 'Sprint Backlog', 'In Progress', 'Done']
 default_skip_copy = ['notes', 'done']
 default_sprint_notes_repo = 'sprint-notes'
+default_days_done = 14


### PR DESCRIPTION
This PR adds the `remove-done-cards` subcommand to `moc-sprint-tools`, and arranges for it to run daily.

There are some additional changes here to reduce our API utilization, because we're regularly hitting our API limits.

- run every 2 hours instead of every 30 minutes
- Add remove-done-cards command
- Separate daily maintenance tasks from more frequent tasks
