### PR TITLE
Do not create sprint notes issue when creating board

### DIFF
--- a/.github/workflows/create-sprint-board.yml
+++ b/.github/workflows/create-sprint-board.yml
@@ -28,6 +28,6 @@ jobs:
       - name: "Create sprint boards"
         run: |
           pipenv run moc-sprint-tools -v create-sprint-boards \
-            --no-copy-cards --conflict-is-warning
+            --no-copy-cards --conflict-is-warning --no-sprint-notes
         env:
           GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}


### PR DESCRIPTION
This adds a new --no-sprint-notes flag to the create-board command and adds
that option to the corresponding github workflow.
