### PR TITLE
Create sprint board 24 hours before sprint planning instead of 2 AM that day

### DIFF
--- a/.github/workflows/create-sprint-board.yml
+++ b/.github/workflows/create-sprint-board.yml
@@ -2,7 +2,7 @@
 name: "Create sprint board"
 on:
   schedule:
-    - cron: '0 2 * * 3'
+    - cron: '0 10 * * 2'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changed the cron schedule to operate every Tuesday at 10AM instead of every Wednesday at 2 AM.